### PR TITLE
Candidate release  of gmpacket v0.1.3 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,5 @@ gmpacket.egg-info/
 .pytest_cache
 *.so
 .vscode/
-MANIFEST.in
 # Vim tags
 tags

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.pyc
 build
+dist
 *~
 .atom/
 .DS_Store

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,3 @@
+recursive-include gmpacket/data *
+prune tests
+prune doc_source

--- a/README.md
+++ b/README.md
@@ -18,4 +18,4 @@ suitability of the data for common engineering/seismological applications.
 [User Documentation](https://scedc.github.io/ground-motion-packet/index.html)
 
 ## Demo
-[Sample Jupyter notebook](https://github.com/SCEDC/ground-motion-packet/blob/main/gmpacket/GMP-demo.ipynb)
+[Sample Jupyter notebook](https://github.com/SCEDC/ground-motion-packet/blob/main/notebooks/pydantic_demo.ipynb)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gmpacket"
-version = "0.1.2"
+dynamic = ["version"]
 description = "ANSS Ground Motion Packet"
 authors = [
     {name = "Mike Hearne", email="mhearne@usgs.gov"},
@@ -69,3 +69,5 @@ requires = [
   "numpy",
 ]
 build-backend = "setuptools.build_meta"
+
+[tool.setuptools_scm]

--- a/setup.py
+++ b/setup.py
@@ -13,9 +13,4 @@ setup(
     url="https://github.com/SCEDC/ground-motion-packet",
     packages=["gmpacket"],
     package_data={"gmpacket": glob.glob("gmpacket/data/**", recursive=True)},
-    entry_points={
-        "console_scripts": [
-            "gmpformat = gmpacket.bin.gmpformat:main",
-        ]
-    },
 )


### PR DESCRIPTION
Getting things set up for a manual upload to PyPi of gmpacket v0.1.3

Adds dynamic versioning for the upload of `dist/` via `pyrpoject.toml`, which operates based on Git tags

