### PR TITLE
Add simple azure-pipelines.yml so we can set up the CI workflow

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,0 +1,53 @@
+# schedules:
+# - cron: "0 6 * * *"
+#   displayName: Daily midnight build
+#   branches:
+#     include:
+#     - main
+#   always: true
+
+pr:
+  - main
+
+trigger:
+  tags:
+    include:
+    - 'dev*'
+
+name: $(Date:yyyyMMdd)$(Rev:.r)
+
+jobs:
+- job: linux
+  timeoutInMinutes: '120'
+  pool: {vmImage: 'Ubuntu-latest'}
+  strategy:
+    matrix:
+      Python38:
+        python.version: '3.8'
+      Python39:
+        python.version: '3.9'
+      Python310:
+        python.version: '3.10'
+  steps:
+    - task: UsePythonVersion@0
+      inputs:
+        versionSpec: '$(python.version)'
+    - bash: |
+        set -o errexit
+        python3 -m pip install --upgrade pip
+        pip3 install cibuildwheel==2.9.0
+      displayName: Install dependencies
+    - bash: cibuildwheel --output-dir wheelhouse .
+      displayName: Build wheels
+    - script: python -m pip install --upgrade twine
+      displayName: 'Install Twine'
+
+    # Download a secure file to the agent machine
+    - task: DownloadSecureFile@1
+      name: securePyPiRC # The name with which to reference the secure file's path on the agent, like $(mySecureFile.secureFilePath)
+      inputs:
+        secureFile: .pypirc
+      
+    # - script: cat $(PYPIRC_PATH)
+    - script: python -m twine upload --skip-existing --non-interactive -r pypi --verbose --config-file $(securePyPiRC.secureFilePath) wheelhouse/*
+      displayName: 'Publish to PyPi through Twine'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -16,38 +16,66 @@ trigger:
 
 name: $(Date:yyyyMMdd)$(Rev:.r)
 
-jobs:
-- job: linux
-  timeoutInMinutes: '120'
-  pool: {vmImage: 'Ubuntu-latest'}
-  strategy:
-    matrix:
-      Python38:
-        python.version: '3.8'
-      Python39:
-        python.version: '3.9'
-      Python310:
-        python.version: '3.10'
-  steps:
-    - task: UsePythonVersion@0
-      inputs:
-        versionSpec: '$(python.version)'
-    - bash: |
-        set -o errexit
-        python3 -m pip install --upgrade pip
-        pip3 install cibuildwheel==2.9.0
-      displayName: Install dependencies
-    - bash: cibuildwheel --output-dir wheelhouse .
-      displayName: Build wheels
-    - script: python -m pip install --upgrade twine
-      displayName: 'Install Twine'
+stages:
+  - stage: test
+    jobs:
+    - job: linux
+      timeoutInMinutes: '120'
+      pool: {vmImage: 'Ubuntu-latest'}
+      strategy:
+        matrix:
+          Python38:
+            python.version: '3.8'
+          Python39:
+            python.version: '3.9'
+          Python310:
+            python.version: '3.10'
+      steps:
+        - task: UsePythonVersion@0
+          inputs:
+            versionSpec: '$(python.version)'
+        - bash: |
+            set -o errexit
+            python3 -m pip install --upgrade pip
+          displayName: Install dependencies
+        - bash: |
+            pip install -e .[dev,test,doc,build]
 
-    # Download a secure file to the agent machine
-    - task: DownloadSecureFile@1
-      name: securePyPiRC # The name with which to reference the secure file's path on the agent, like $(mySecureFile.secureFilePath)
-      inputs:
-        secureFile: .pypirc
-      
-    # - script: cat $(PYPIRC_PATH)
-    - script: python -m twine upload --skip-existing --non-interactive -r pypi --verbose --config-file $(securePyPiRC.secureFilePath) wheelhouse/*
-      displayName: 'Publish to PyPi through Twine'
+            pytest .
+
+  # - stage: deploy
+  #   jobs:
+  #   - job: linux
+  #     timeoutInMinutes: '120'
+  #     pool: {vmImage: 'Ubuntu-latest'}
+  #     strategy:
+  #       matrix:
+  #         Python38:
+  #           python.version: '3.8'
+  #         Python39:
+  #           python.version: '3.9'
+  #         Python310:
+  #           python.version: '3.10'
+  #     steps:
+  #       - task: UsePythonVersion@0
+  #         inputs:
+  #           versionSpec: '$(python.version)'
+  #       - bash: |
+  #           set -o errexit
+  #           python3 -m pip install --upgrade pip
+  #           # pip3 install cibuildwheel==2.9.0
+        #  displayName: Install dependencies
+        # - bash: cibuildwheel --output-dir wheelhouse .
+        #   displayName: Build wheels
+        # - script: python -m pip install --upgrade twine
+        #   displayName: 'Install Twine'
+
+        # Download a secure file to the agent machine
+        # - task: DownloadSecureFile@1
+        #   name: securePyPiRC # The name with which to reference the secure file's path on the agent, like $(mySecureFile.secureFilePath)
+        #   inputs:
+        #     secureFile: .pypirc
+          
+        # # - script: cat $(PYPIRC_PATH)
+        # - script: python -m twine upload --skip-existing --non-interactive -r pypi --verbose --config-file $(securePyPiRC.secureFilePath) wheelhouse/*
+        #   displayName: 'Publish to PyPi through Twine'


### PR DESCRIPTION
This `azure-pipelines.yml` file just tries installing the code and running tests for a few versions of Python on Linux.

Its presence will allow us to configure a new project on Azure DevOps and connect to this repository so we can automate testing, package building, and deployment
